### PR TITLE
Fix agent image handling: detect local file paths and ask submitter to upload

### DIFF
--- a/.github/agents/website-maintainer.agent.md
+++ b/.github/agents/website-maintainer.agent.md
@@ -94,7 +94,10 @@ Check that every required field is filled and not left as the template placehold
 Check whether translated text is provided for all selected languages. If some language sections say "same as English" or are blank, note this — you will need to ask the submitter for the missing translations before implementing.
 
 **For Template 01 — image check:**
-If a photo URL is provided, attempt to fetch it to confirm it is reachable.
+Inspect the "Photo or image" field:
+- **If it contains a URL** (starts with `http://` or `https://`): attempt to fetch it to confirm it is reachable. If unreachable, flag it.
+- **If it contains a local file path** (starts with `/`, `~`, `C:\`, `C:/`, `/Users/`, `/home/`, or any pattern that is clearly a path on the submitter's machine): this file is **inaccessible** to the agent. Flag it — ask the submitter to attach the image directly to the GitHub issue as a file attachment (drag and drop onto the issue text area).
+- **If the field is empty or absent:** no image is available; proceed without one.
 
 **For Templates 02 and 04 — source file check:**
 Derive the likely `.qmd` source path from the provided URL. Example:
@@ -165,7 +168,10 @@ Load the relevant instruction file before writing any `.qmd` files:
    - Add any free-form tags from the extra-categories field
 3. Write body from the "Full story" field
 4. Add Key Information callout if location and/or link were provided
-5. If a photo URL was provided: download to `Materials/photos/`, update `image:` frontmatter, add image block in body with `fig-alt` and caption
+5. Handle the "Photo or image" field:
+   - **If a URL was provided and is reachable:** download to `Materials/photos/`, update `image:` frontmatter, add image block in body with `fig-alt` and caption
+   - **If a local file path was provided:** do NOT include an `image:` field — the path is on the submitter's machine and is inaccessible. This case should have been caught in Step A3; if it was not, omit the image entirely and note the omission in the PR description
+   - **If absent:** omit the `image:` field entirely
 
 **For Template 02 (content update):**
 1. Identify the `.qmd` file(s) from the page URL and selected languages

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -25,6 +25,7 @@ Report each item as **PASS** or **FLAG**.
 | No placeholder text remaining | No template skeleton text such as `"Write a short introductory paragraph here."`, `"Describe the problem here."`, or similar |
 | Dates, links, names match issue | Values in the file match what the submitter provided |
 | Image path is real or omitted | `image:` in frontmatter points to a file that actually exists in `Materials/photos/`, or is absent |
+| Image omission noted if photo was requested | If the issue provided a photo (local path or unreachable URL) but the post has no `image:`, confirm the PR description explains why and that the submitter was asked to provide the file |
 
 ### 3. File Paths and Links
 


### PR DESCRIPTION
## Summary
The website-maintainer agent was silently omitting images when a submitter provided a local file path (e.g. \/Users/.../image.jpg\) in the photo field. It had no rule to distinguish a local path from a URL, so it simply skipped the image without asking. This was observed in issue #31.

## Changes
- \.github/agents/website-maintainer.agent.md\ — Step A3: added explicit 3-way check (URL / local path / absent) for the photo field; local paths are now flagged in the validation comment asking the submitter to attach the file to the GitHub issue instead
- \.github/agents/website-maintainer.agent.md\ — Step C Template 01: replaced the single-case image instruction with a 3-way handler matching the validation logic
- \.github/instructions/review.instructions.md\ — added a review check: if the issue provided a photo but the post has no \image:\, verify the PR description explains why and that the submitter was asked to provide the file

A comment has also been posted on issue #31 asking @elizabethastroud to attach her photo as a GitHub file attachment.

## Closes
- Addresses the root cause found in #31 / PR #32

---
_@OndrejMottl — please mark this PR as ready for review._